### PR TITLE
Update let's encrypt repository

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,7 +15,7 @@ services:
       - certs:/etc/nginx/certs:ro
       - /var/run/docker.sock:/tmp/docker.sock:ro
   letsencrypt:
-    image: jrcs/letsencrypt-nginx-proxy-companion
+    image: nginxproxy/acme-companion
     container_name: nginx-proxy-le
     restart: unless-stopped
     volumes:


### PR DESCRIPTION
Updated let's encrypt container image for the new registry as the old one is now deprecated. Reference https://hub.docker.com/r/jrcs/letsencrypt-nginx-proxy-companion